### PR TITLE
Adds install rules, add more standard variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,27 +1,36 @@
+SHELL = /bin/sh
 # gfortran options:
 #  -g ->include source level debugging support
 #  -ffixed-form -> for Fortran 77 fixed form parsing
 #  -fd-lies-as-code -> include debugging statements
 #  -fd-lines-as-comments -> ignore debugging statements
 #DEBUG= -fd-lines-as-code
-DEST = ../dist
-FC = gfortran -g  -ffixed-form -fd-lines-as-comments $(DEBUG)
+DESTDIR = ../dist
+FC = gfortran
+FFLAGS = -g  -ffixed-form -fd-lines-as-comments $(DEBUG)
 OBJS = dungeon.o game.o gdt.o objects.o parser.o rooms.o subr.o timefnc.o verbs.o
-DATAFILES = data/dtext data/dindx
+DATA_FILES = data/dtext data/dindx
 EXE = dungeon
+DIST_FILE = ${EXE}_distribution.tgz
 
 all : ${EXE}
 
-dist : ${EXE}
-	rm -rf ${DEST}
-	mkdir -p ${DEST}
-	cp ${EXE} ${DEST}
-	strip ${DEST}/$(EXE)
-	cp ${DATAFILES} ${DEST}
+dist : all
+	rm -rf ${DESTDIR}
+	mkdir -p ${DESTDIR}
+	cp ${EXE} ${DESTDIR}
+	strip ${DESTDIR}/$(EXE)
+	cp ${DATA_FILES} ${DESTDIR}
+	tar czf ${DIST_FILE} ${DESTDIR}
 
-dungeon : $(OBJS)
+${EXE} : $(OBJS)
 	$(FC) -o $(EXE) $^
 
 clean:
-	rm -rf ${DEST}
 	rm -f ${EXE} ${OBJS}
+
+clobber: clean
+	rm -rf ${DESTDIR} ${DIST_FILE}
+
+install:
+	@echo "install rule not implemented yet."


### PR DESCRIPTION
In doing a little reading, I remembered that the "dist" rule is for
creating a distribution file and there is an "install" rule to put the
file(s) into the appropriate installation directory and verify file
protections.  Also, that FC is just for the name of the compiler and
FFLAGS is for the flags.  The implied compile rules use this convention.
(See GNU Make Manual, Automatic Variables) for details.

This commit adds the standard variables, adds a tar command to create
the distribution file and adds a stub for the install rule.
ZZ
